### PR TITLE
Bug Fix

### DIFF
--- a/src/ipv4defrag.c
+++ b/src/ipv4defrag.c
@@ -451,7 +451,7 @@ inline static void ip_check_timeouts ( pntoh_ipv4_session_t session )
 			if ( DEFAULT_IPV4_FRAGMENT_TIMEOUT < tv.tv_sec - item->last_activ.tv_sec )
 			{
 				lock_access ( &item->lock );
-				__ipv4_free_flow ( session , &item , NTOH_REASON_TIMEDOUT );
+				__ipv4_free_flow ( session , &item , NTOH_REASON_TIMEDOUT_FRAGMENTS );
 				node = prev;
 			}else{
 				prev = node;


### PR DESCRIPTION
The reason returned when the flow was freed was set out in the header file as belonging to tcp, rather than IP.  Changed the reason so they are now consistent.

Not sent a pull req before, so please shout if it isn't right.
