### PR TITLE
Bug Fix

### DIFF
--- a/src/ipv4defrag.c
+++ b/src/ipv4defrag.c
@@ -452,7 +452,12 @@ inline static void ip_check_timeouts ( pntoh_ipv4_session_t session )
 			{
 				lock_access ( &item->lock );
 				__ipv4_free_flow ( session , &item , NTOH_REASON_TIMEDOUT );
-				node = prev;
+				if (node != prev)
+				{
+				      node = prev;
+				}else{
+				      node = 0;
+				}
 			}else{
 				prev = node;
 				node = node->next;

--- a/src/tcpreassembly.c
+++ b/src/tcpreassembly.c
@@ -306,7 +306,12 @@ inline static void tcp_check_timeouts ( pntoh_tcp_session_t session )
 			{
 				lock_access ( &item->lock );
 				__tcp_free_stream ( session , &item , NTOH_REASON_SYNC , NTOH_REASON_TIMEDOUT );
-				node = prev;
+				if (node != prev)
+				{
+                                       node = prev;
+                                }else{
+                                       node = 0;
+                                }
 			}else{
 				prev = node;
 				node = node->next;


### PR DESCRIPTION
Fixed bug in timeout functions that occured when there was only one item in the list.  This cause the thread to hang when it tried to lock_access on a junk pointer.
